### PR TITLE
Fix typo in headless flag help

### DIFF
--- a/bizneo_browser.py
+++ b/bizneo_browser.py
@@ -6,7 +6,7 @@ from src.browser.library import add_expected_schedule
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--date", required=False, help="Fecha en formato YYYY-M-D (Default: today)")
-    parser.add_argument("--headless", action="store_true", help="Run browswer in headless mode")
+    parser.add_argument("--headless", action="store_true", help="Run browser in headless mode")
     args = parser.parse_args()
     if args.date:
         args.date = datetime.strptime(args.date, "%Y-%m-%d")


### PR DESCRIPTION
`browswer` -> `browser`