### PR TITLE
Fix locator all

### DIFF
--- a/src/browser/library.py
+++ b/src/browser/library.py
@@ -103,7 +103,7 @@ def register_schedule(page, user_id, year, month, day):
         print("Schedule was already registered")
         return False
 
-    for element in page.locator(add_default_schedule_selector).all():
+    for element in page.locator(add_default_schedule_selector).element_handles():
         if element.is_visible():
             element.click()
 
@@ -126,4 +126,4 @@ def check_registration_was_ok(page, user_id, year, month, day):
 
 
 def any_locator_is_visible(page, selector):
-    return any([x.is_visible() for x in page.locator(selector).all()])
+    return any([x.is_visible() for x in page.locator(selector).element_handles()])


### PR DESCRIPTION
I was having this issue in bizneo:
```
❯ /home/angel/.local/bin/poetry run bizneo browser expected     --headless --browser chromium
  File "/home/angel/aa/python-bizneo/src/browser/library.py", line 130, in any_locator_is_visible
    return any([x.is_visible() for x in page.locator(selector).all()])
AttributeError: 'Locator' object has no attribute 'all'
```
And the fix for me (suggested by chatgpt) is to change all() to element_handles() in a couple of places 
