### PR TITLE
feat(browser): add desktop notification when not logged in

### DIFF
--- a/bizneo.nix
+++ b/bizneo.nix
@@ -1,4 +1,7 @@
 {
+  lib,
+  stdenv,
+  libnotify,
   makeWrapper,
   installShellFiles,
   playwright-driver,
@@ -37,7 +40,8 @@ python3Packages.buildPythonApplication {
   postFixup = ''
     wrapProgram $out/bin/bizneo \
       --set-default PLAYWRIGHT_BROWSERS_PATH ${playwright-driver.browsers} \
-      --set-default PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS true
+      --set-default PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS true \
+      ${lib.optionalString stdenv.isLinux "--prefix PATH : ${lib.makeBinPath [ libnotify ]}"}
   '';
 
   doInstallCheck = true;

--- a/src/browser/library.py
+++ b/src/browser/library.py
@@ -3,6 +3,8 @@ from os import path
 from glob import glob
 from playwright.sync_api import sync_playwright, TimeoutError as PlaywrightTimeoutError
 
+from src.browser.notify import send_notification
+
 
 PROFILE_PATH = ""
 HOME_PATH = path.expanduser("~")
@@ -22,8 +24,9 @@ def add_expected_schedule(headless, browser):
         browser, page = get_browser_and_page(playwright, headless, browser)
         page.goto("https://sysdig.bizneohr.com")
 
-        if page.locator('//p[text()="Log in with"]').count() > 0:
+        if page.locator('//p[normalize-space()="Log in to Sysdig"]').count() > 0:
             print("User not logged in. Run bizneo browser login.")
+            send_notification("Bizneo", "Not logged in. Run: bizneo browser login")
             return
 
         today_locator = '//div[@class="day-header today"]'

--- a/src/browser/notify.py
+++ b/src/browser/notify.py
@@ -1,0 +1,16 @@
+import subprocess
+import sys
+
+
+def send_notification(title: str, message: str) -> None:
+    """Send a desktop notification. Best-effort: silently ignores failures."""
+    try:
+        if sys.platform == "darwin":
+            subprocess.run(
+                ["osascript", "-e", f'display notification "{message}" with title "{title}"'],
+                timeout=5,
+            )
+        elif sys.platform == "linux":
+            subprocess.run(["notify-send", title, message], timeout=5)
+    except Exception:
+        pass


### PR DESCRIPTION
`bizneo browser expected` runs as a background service, so when the session expires the user has no way to know they need to re-login. This adds a native desktop notification (via `osascript` on macOS, `notify-send` on Linux) to make the failure visible.

<img width="373" height="73" alt="image" src="https://github.com/user-attachments/assets/800f6d1a-fdeb-48d4-bb68-5aa1d7ae6402" />
<img width="985" height="177" alt="image" src="https://github.com/user-attachments/assets/bbe1c5d4-7ebb-48bf-a886-e7e782d4bd19" />



Also fixes login detection: the Bizneo login page now shows "Log in to Sysdig" instead of the old "Log in with" text, and uses `normalize-space()` for whitespace-safe XPath matching.