### PR TITLE
fix(reports): detect non-working day logs and ignore project hours

### DIFF
--- a/bizneo.py
+++ b/bizneo.py
@@ -191,74 +191,77 @@ def individual_reports(comment, start_at, end_at, webhook, headers, taxon, dry_r
         click.echo(f"No users with Slack ID found{f' for taxon: {taxon}' if taxon else ''}")
         return
 
-    click.echo(f"Sending individual reports to {len(users_with_slack)} users...")
+    click.echo(f"Checking {len(users_with_slack)} users with Slack ID...")
     click.echo(f"Date range: [{start_at}, {end_at}]")
     click.echo(f"Dry-run mode: {'ON' if dry_run else 'OFF'}\n")
 
-    success_count = 0
+    from src.api.bizneo_requestor import get_user_schedules, get_user_logged_times
+    from src.api.reports_tasks import _get_report_user_issues, _get_report_user_string
+
+    pending_messages = []
     skip_count = 0
-    error_no_slack_count = 0
+    no_slack_with_issues = []
 
+    click.echo("=== Checking phase ===")
     for user in users_with_slack:
-        # Generate individual report for this user using the same logic as test_single_user
-        from src.api.bizneo_requestor import get_user_schedules, get_user_logged_times
-        from src.api.reports_tasks import _get_report_user_issues, _get_report_user_string
-
         schedules = get_user_schedules(user.user_id, start_at, end_at)
         logged_times = get_user_logged_times(user.user_id, start_at, end_at)
         issues = _get_report_user_issues(schedules, logged_times)
 
-        # Check if user has issues to report
         if not issues:
             skip_count += 1
-            click.echo(f"⏭️  Skipping {user.first_name} {user.last_name} - no issues")
+            click.echo(f"  ⏭️  {user.first_name} {user.last_name} - no issues")
             continue
 
-        # Build the report with issues
         user_string = _get_report_user_string(user, start_at, "")
+        header_line = f"Reporte para el rango de fechas: [{start_at}, {end_at}]"
         if comment:
-            user_report = (
-                f"{comment}\nReporte para el rango de fechas: [{start_at}, {end_at}]\n{user_string}\n{issues}"
-            )
+            user_report = f"{comment}\n{header_line}\n{user_string}\n{issues}"
         else:
-            user_report = f"Reporte para el rango de fechas: [{start_at}, {end_at}]\n{user_string}\n{issues}"
+            user_report = f"{header_line}\n{user_string}\n{issues}"
 
-        # Prepare headers with user's slack channel
         user_headers = headers.copy() if headers else {}
         user_headers["channel-id"] = user.slack_id
 
-        if dry_run:
-            click.echo(f"\n{'='*60}")
-            click.echo(f"DRY-RUN: Would send to {user.first_name} {user.last_name}")
-            click.echo(f"Slack ID: {user.slack_id}")
-            click.echo(f"Webhook: {webhook}")
-            click.echo(f"Headers: {user_headers}")
-            click.echo(f"\nReport content:\n{user_report}")
-            click.echo(f"{'='*60}\n")
-            success_count += 1
-        else:
-            ok, response = send_message_to_webhook(webhook, user_report, user_headers)
-            if ok:
-                click.echo(f"✅ Sent to {user.first_name} {user.last_name} ({user.slack_id})")
-                success_count += 1
-            else:
-                click.echo(f"❌ Error sending to {user.first_name} {user.last_name}: {response}")
+        pending_messages.append((user, user_headers, user_report))
+        click.echo(f"  ⚠️  {user.first_name} {user.last_name} - issues found")
 
-    # Check for users without Slack ID who have time issues
     for user in users_without_slack:
         schedules = get_user_schedules(user.user_id, start_at, end_at)
         logged_times = get_user_logged_times(user.user_id, start_at, end_at)
         issues = _get_report_user_issues(schedules, logged_times)
         if issues:
-            error_no_slack_count += 1
+            no_slack_with_issues.append(user)
             click.echo(
-                f"⚠️  ERROR: {user.first_name} {user.last_name} ({user.email}) has time issues but NO Slack ID configured!"
+                f"  ⚠️  ERROR: {user.first_name} {user.last_name} ({user.email}) has issues but NO Slack ID"
             )
 
-    click.echo(f"\n{'Dry-run' if dry_run else 'Sending'} completed:")
-    click.echo(f"  - Sent: {success_count}")
+    click.echo(f"\n=== {'Messages that would be sent' if dry_run else 'Sending messages'} ===")
+    success_count = 0
+    error_count = 0
+    for user, user_headers, user_report in pending_messages:
+        click.echo(f"\n{'-'*60}")
+        click.echo(f"→ {user.first_name} {user.last_name} (slack_id={user.slack_id})")
+        click.echo(f"Headers: {user_headers}")
+        click.echo(f"\n{user_report}")
+        if dry_run:
+            success_count += 1
+        else:
+            ok, response = send_message_to_webhook(webhook, user_report, user_headers)
+            if ok:
+                click.echo("✅ Sent")
+                success_count += 1
+            else:
+                click.echo(f"❌ Error: {response}")
+                error_count += 1
+    click.echo(f"{'-'*60}\n")
+
+    click.echo(f"=== {'Dry-run' if dry_run else 'Sending'} summary ===")
+    click.echo(f"  - {'Would send' if dry_run else 'Sent'}: {success_count}")
+    if not dry_run:
+        click.echo(f"  - Send errors: {error_count}")
     click.echo(f"  - Skipped (no issues): {skip_count}")
-    click.echo(f"  - Errors (no Slack ID but has issues): {error_no_slack_count}")
+    click.echo(f"  - Errors (no Slack ID but has issues): {len(no_slack_with_issues)}")
     click.echo(f"  - Total users with Slack ID: {len(users_with_slack)}")
     click.echo(f"  - Total users without Slack ID: {len(users_without_slack)}")
 

--- a/src/api/logged_time.py
+++ b/src/api/logged_time.py
@@ -1,18 +1,55 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+
+
+def _parse_hours(time_str):
+    if not time_str:
+        return 0.0
+    parts = time_str.split(":")
+    h = int(parts[0])
+    m = int(parts[1]) if len(parts) > 1 else 0
+    s = int(parts[2]) if len(parts) > 2 else 0
+    return h + m / 60 + s / 3600
 
 
 @dataclass
 class LoggedTime:
-    date: int
-    total_hours: str
+    date: str
+    total_hours: float
+    project_hours: float = 0.0
+    project_ids: set = field(default_factory=set)
 
     @classmethod
     def from_dict(cls, data: dict):
+        lt = data.get("logged_time", {})
+        project_hours = 0.0
+        project_ids = set()
+        for lh in lt.get("logged_hours", []):
+            projects = lh.get("projects") or []
+            if not projects:
+                continue
+            start = lh.get("start_at")
+            end = lh.get("end_at")
+            if start and end:
+                duration = _parse_hours(end) - _parse_hours(start)
+                if duration < 0:
+                    duration += 24
+                project_hours += duration
+            project_ids.update(projects)
         return cls(
-            date=data.get("logged_time", {}).get("date"),
-            total_hours=float(data.get("logged_time", {}).get("total_hours")),
+            date=lt.get("date"),
+            total_hours=float(lt.get("total_hours")),
+            project_hours=project_hours,
+            project_ids=project_ids,
         )
 
     @property
     def has_logged_time(self):
         return self.total_hours > 0
+
+    @property
+    def regular_hours(self):
+        return self.total_hours - self.project_hours
+
+    @property
+    def has_projects(self):
+        return bool(self.project_ids)

--- a/src/api/reports_tasks.py
+++ b/src/api/reports_tasks.py
@@ -31,15 +31,33 @@ def get_time_report(taxon, start_at, end_at, comment):
 
 
 def _get_report_user_issues(schedules, logged_times):
-    issues = ""
-    for schedule in [x for x in schedules if x.is_working_day]:
-        for logged_time in logged_times:
-            if schedule.date == logged_time.date and (
-                not logged_time.has_logged_time
-                or logged_time.total_hours not in [EXPECTED_WORKING_HOURS, EXPECTED_HALF_WORKING_HOURS]
-            ):
-                issues += f"  - {schedule.date}: {logged_time.total_hours} horas\n"
-    return issues
+    working_dates = {s.date for s in schedules if s.is_working_day}
+    logged_by_date = {lt.date: lt for lt in logged_times}
+
+    issue_lines = []
+    for date in sorted(working_dates):
+        lt = logged_by_date.get(date)
+        if lt is None or not lt.has_logged_time:
+            issue_lines.append(f"  - {date}: 0 horas (día laboral sin registro)")
+            continue
+        regular = lt.regular_hours
+        if regular >= EXPECTED_WORKING_HOURS or regular == EXPECTED_HALF_WORKING_HOURS:
+            continue
+        suffix = f" ({lt.project_hours:g}h en proyecto)" if lt.has_projects else ""
+        issue_lines.append(f"  - {date}: {regular:g} horas regulares{suffix}")
+
+    for date in sorted(logged_by_date):
+        lt = logged_by_date[date]
+        if date in working_dates or not lt.has_logged_time:
+            continue
+        if lt.regular_hours <= 0:
+            continue
+        suffix = f" ({lt.project_hours:g}h en proyecto)" if lt.has_projects else ""
+        issue_lines.append(
+            f"  - {date}: {lt.regular_hours:g} horas regulares (día no laboral con registro){suffix}"
+        )
+
+    return "\n".join(issue_lines) + "\n" if issue_lines else ""
 
 
 def _get_report_user_string(user, start_at, comment):


### PR DESCRIPTION
## Summary
- Detect logs on non-working days (weekends/holidays/absence days) that previously slipped past the working-day-only iteration.
- Parse `logged_hours.projects` to compute project hours per day and exclude project-attributed hours (e.g. "Horas en llamada On-Call") from issue checks. Working days now pass when regular hours `>= 8` or `== 4`; non-working days pass when regular hours `== 0`.
- Restructure `admin time individual-reports` output into two phases: a checking phase with per-user progress, then a messages phase that lists all reports that would be sent (dry-run) or were sent.

## Verification
Ran against April 2026 data:
- David Lorite: no longer flagged (on-call hours subtracted from totals).
- Diego Hernandez: still flagged for 2026-04-24 (8h logged on non-working day).
- Marcelo Berges: still flagged for 2026-04-02 (8h logged on non-working day).

## Test plan
- [x] Run `bizneo admin time individual-reports --dry-run` against last month and inspect the checking/messages phases.
- [x] Confirm users with on-call hours on working days are not flagged when regular hours are at or above the threshold.
- [x] Confirm users with extra logs on weekends/holidays are still flagged.