### PR TITLE
fix(browser): correct Chromium macOS profile path

### DIFF
--- a/src/browser/library.py
+++ b/src/browser/library.py
@@ -8,7 +8,7 @@ from src.browser.notify import send_notification
 
 PROFILE_PATH = ""
 HOME_PATH = path.expanduser("~")
-CHROMIUM_MACOS_PROFILE_PATH = f"{HOME_PATH}~/Library/Application Support/Chromium"
+CHROMIUM_MACOS_PROFILE_PATH = f"{HOME_PATH}/Library/Application Support/Chromium"
 CHROMIUM_LINUX_PROFILE_PATH = f"{HOME_PATH}/.config/chromium"
 CHROMIUM_LINUX_SNAP_PROFILE_PATH = f"{HOME_PATH}/snap/chromium/common/chromium"
 CHROMIUM_PATHS = [CHROMIUM_MACOS_PROFILE_PATH, CHROMIUM_LINUX_PROFILE_PATH, CHROMIUM_LINUX_SNAP_PROFILE_PATH]


### PR DESCRIPTION
## Summary
- Remove stray `~` after `HOME_PATH` in `CHROMIUM_MACOS_PROFILE_PATH`, which produced an invalid path like `/Users/<user>~/Library/Application Support/Chromium` and prevented Chromium on macOS from resolving the user's real profile.

## Test plan
- [ ] Run `uv run bizneo browser expected --browser chromium` on macOS and confirm the Chromium profile loads (no fallback to the Linux path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)