### PR TITLE
docs: add periodic validations section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,35 @@ inputs = {
 
 On Linux this creates a systemd user service + timer. On macOS it creates a launchd agent with logs at `~/Library/Logs/bizneo/`.
 
+## Periodic Validations
+
+Before running the validations:
+
+1. Configure the API token in `src/api/bizneo_requestor.py`.
+2. Make sure every employee has a `slack_id` assigned.
+
+### Weekly (every Tuesday)
+
+```sh
+uv run bizneo admin time individual-reports \
+  --comment "Hola, estoy revisando los registros de la semana anterior 💌" \
+  --webhook "${ZAPIER_WEBHOOK_URL}" \
+  --headers "{'emoji': ':bizneo:'}"
+```
+
+### Monthly (around the 15th of each month)
+
+```sh
+uv run bizneo admin time individual-reports \
+  --start_at $(date -d "$(date +%Y-%m-01) -1 month" +%Y-%m-%d) \
+  --end_at $(date -d "$(date +%Y-%m-01) -1 day" +%Y-%m-%d) \
+  --comment "Hola, estoy revisando los registros del mes anterior 💌" \
+  --webhook "${ZAPIER_WEBHOOK_URL}" \
+  --headers "{'emoji': ':bizneo:'}"
+```
+
+Add `--dry-run` to either command to preview without sending.
+
 ## License
 
 This project is licensed under the [GPL-3.0 License](LICENSE).


### PR DESCRIPTION
## Summary
- Add `## Periodic Validations` section to README
- Document prereqs (API token, employee `slack_id`), weekly Tuesday run, and monthly run (~15th)
- Use `${ZAPIER_WEBHOOK_URL}` placeholder instead of hardcoded webhook URL
- Note `--dry-run` available for previews

## Test plan
- [ ] Render README on GitHub, verify section renders correctly