### PR TITLE
Support dedicated browser profile and detect logout by URL

### DIFF
--- a/src/browser/library.py
+++ b/src/browser/library.py
@@ -1,3 +1,4 @@
+import os
 from typing import List
 from os import path
 from glob import glob
@@ -6,7 +7,7 @@ from playwright.sync_api import sync_playwright, TimeoutError as PlaywrightTimeo
 from src.browser.notify import send_notification
 
 
-PROFILE_PATH = ""
+PROFILE_PATH = os.environ.get("BIZNEO_PROFILE_PATH", "")
 HOME_PATH = path.expanduser("~")
 CHROMIUM_MACOS_PROFILE_PATH = f"{HOME_PATH}/Library/Application Support/Chromium"
 CHROMIUM_LINUX_PROFILE_PATH = f"{HOME_PATH}/.config/chromium"
@@ -23,8 +24,9 @@ def add_expected_schedule(headless, browser):
     with sync_playwright() as playwright:
         browser, page = get_browser_and_page(playwright, headless, browser)
         page.goto("https://sysdig.bizneohr.com")
+        page.wait_for_load_state("networkidle")
 
-        if page.locator('//p[normalize-space()="Log in to Sysdig"]').count() > 0:
+        if "/sessions/new" in page.url:
             print("User not logged in. Run bizneo browser login.")
             send_notification("Bizneo", "Not logged in. Run: bizneo browser login")
             return


### PR DESCRIPTION
## Description

Two small fixes to make the scheduled `bizneo browser expected` run work reliably from cron.

### `BIZNEO_PROFILE_PATH` env var
`PROFILE_PATH` now reads from a `BIZNEO_PROFILE_PATH` environment variable (falling back to the previous default-profile detection when unset).

This lets a scheduled run use a **dedicated** browser profile instead of the user's everyday one. Launching a persistent context against the default profile fails when a normal browser is already open (`"A copy of <browser> is already open. Only one copy can be open at a time."`), which made the cron fail every time during working hours.

Usage:
```
BIZNEO_PROFILE_PATH=/path/to/dedicated-profile bizneo browser expected --headless --browser chromium
```

### Language-independent login detection
The login check used an English-only locator (`"Log in to Sysdig"`). On a Spanish UI it never matched, so a logged-out session fell through the check and the command printed a misleading `"Schedule already registered"` without registering anything.

It now checks whether the page redirected to `/sessions/new` (after waiting for `networkidle`), which is language-independent and correctly reports the logged-out state.

## Testing
- Verified `expected --headless --browser chromium` against a dedicated, logged-in Chromium profile: registers the schedule (`"Schedule registered"`) and reports `"Schedule already registered"` on subsequent runs.
- Verified a logged-out profile now prints `"User not logged in. Run bizneo browser login."` instead of a false `"Schedule already registered"`.