### PR TITLE
fix: use stdenv.hostPlatform.system instead of deprecated pkgs.system

### DIFF
--- a/bizneo-module-home.nix
+++ b/bizneo-module-home.nix
@@ -44,7 +44,7 @@ in
 
       package = mkOption {
         type = types.package;
-        default = flake.packages.${pkgs.system}.bizneo;
+        default = flake.packages.${pkgs.stdenv.hostPlatform.system}.bizneo;
         description = "The bizneo package to use.";
       };
     };

--- a/bizneo-module.nix
+++ b/bizneo-module.nix
@@ -46,7 +46,7 @@ in
   };
 
   config = mkIf cfg.enable {
-    nixpkgs.overlays = [ (final: prev: { bizneo = flake.packages.${prev.system}.bizneo; }) ];
+    nixpkgs.overlays = [ (final: prev: { bizneo = flake.packages.${prev.stdenv.hostPlatform.system}.bizneo; }) ];
 
     environment.systemPackages = [ cfg.package ];
 


### PR DESCRIPTION
`pkgs.system` / `prev.system` emit a deprecation warning since nixpkgs 2025-10-28 (`'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'`). Switch both module accessors to the non-deprecated path to silence it for consumers.